### PR TITLE
Add mappings for pagefooter/pageheader

### DIFF
--- a/index.html
+++ b/index.html
@@ -875,6 +875,46 @@ var mappingTableLabels = {
                                                                     AXRoleDescription: <code>'splitter'</code>
                                                                 </td>
                                                         </tr>
+                                                        <tr id="role-map-pagefooter">
+                                                                <th><a class="dpub-role-reference" href="#doc-pagefooter"><code>doc-pagefooter</code></a></th>
+                                                                <td>
+                                                                        Expose IAccessible2:
+                                                                        <ul>
+                                                                                <li><code>IA2_ROLE_FOOTER</code></li>
+                                                                                <li>Object attribute <code>xml-roles:doc-pagefooter</code> </li>
+                                                                        </ul>
+                                                                </td>
+                                                                <td>
+                                                                  <ul>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>pagefooter</code>'</li>
+                                                                  </ul>
+                                                                </td>
+                                                                <td>Expose <p><code>ROLE_FOOTER</code> and object attribute <code>xml-roles:doc-pagefooter</code>. </p></td>
+                                                                <td>AXRole: <code>AXGroup</code><br />
+                                                                        AXSubrole: <code>&lt;nil&gt;</code>
+                                                                </td>
+                                                        </tr>
+                                                        <tr id="role-map-pageheader">
+                                                                <th><a class="dpub-role-reference" href="#doc-pageheader"><code>doc-pageheader</code></a></th>
+                                                                <td>
+                                                                        Expose IAccessible2:
+                                                                        <ul>
+                                                                                <li><code>IA2_ROLE_HEADER</code></li>
+                                                                                <li>Object attribute <code>xml-roles:doc-pageheader</code> </li>
+                                                                        </ul>
+                                                                </td>
+                                                                <td>
+                                                                  <ul>
+                                                                    <li>Control Type is <code>Text</code></li>
+                                                                    <li>Localized Control Type is '<code>pageheader</code>'</li>
+                                                                  </ul>
+                                                                </td>
+                                                                <td>Expose <p><code>ROLE_HEADER</code> and object attribute <code>xml-roles:doc-pageheader</code>. </p></td>
+                                                                <td>AXRole: <code>AXGroup</code><br />
+                                                                        AXSubrole: <code>&lt;nil&gt;</code>
+                                                                </td>
+                                                        </tr>
                                                         <tr id="role-map-pagelist">
                                                                 <th><a class="dpub-role-reference" href="#doc-pagelist"><code>doc-pagelist</code></a></th>
                                                                 <td>


### PR DESCRIPTION
IA2: IA2_ROLE_FOOTER/HEADER
ATK: ATK_ROLE_FOOTER/HEADER
Mac: AXGroup, could use more detailed mappings from @cookiecrook 
UIA: unknown, could use more detailed mappings 