### PR TITLE
General document cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
-		<title>Digital Publishing Accessibility API Mappings</title>
+		<title>Digital Publishing Accessibility API Mappings 1.1</title>
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<script src="common/script/jquery-1.9.0.min.js"></script>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
@@ -23,7 +23,7 @@
     //publishDate:           "2013-08-22",
 
     // the specifications short name, as in http://www.w3.org/TR/short-name/
-    shortName:            "dpub-aam-1.0",
+    shortName:            "dpub-aam-1.1",
           
     // if you wish the publication date to be other than today, set this
     // publishDate:  "2009-08-06",
@@ -1148,61 +1148,35 @@ var mappingTableLabels = {
 		</section>
 		<section id="appendices" class="appendix">
 			<h2>Appendices</h2>
-        		<section class="appendix" id="changelog">
-                		<h2>Change Log</h2>
-                		<section>
-                        		<h2>Substantive changes since the <a href="https://www.w3.org/TR/2015/WD-dpub-aam-1.0-20151203/">last public working draft</a></h2>
-                        		<ul>
-                                		<li>20-Apr-2017: Update mappings. For AXAPI, the AXSubrole is now AXApplicationGroup for the following roles: doc-abstract, doc-colophon, doc-dedication, doc-epigraph, doc-example, doc-footnote, doc-pullquote, and doc-qna; the AXRoleDescription of doc-abstract is now 'group'; doc-pagebreak is now mapped to AXRole: AXSplitter, AXRoleDescription: 'splitter'; doc-notice and doc-tip are now mapped to AXSubrole: AXDocumentNote, AXRoleDescription: 'note'. For ATK/ATSPI2, doc-tip is now mapped to ROLE_COMMENT.</li>
-                                		<li>20-Apr-2017: Map doc-pullquote for ATK/ATSPI2, IA2, and UIA.</li>
-                                		<li>10-Mar-2016: Replace all ROLE_PANEL to ROLE_SECTION for ATK/ATSPI mappings</li>
-                                		<li>10-Mar-2016: Replace doc-locator with doc-backlink</li>
-						<li>10-Mar-2016: Remove doc-title</li>
-                                		<li>10-Mar-2016: Remove doc-footnotes and add doc-endnote and doc-endnotes</li>
-                                		<li>10-Mar-2016: Changed doc-pullquote to reflect no mappings</li>
-                                		<li>10-Mar-2016: Change doc-cover to map to an image</li>
-						<li>10-Mar-2016: Removed rendundant references section in the appendix</li>
-						<li>10-Mar-2016: Fixed links for githumb.io in configuration</li>
-						<li>10-Mar-2016: Added a change log </li>
-                                                <li>10-Mar-2016: Remove editors note regarding @rel </li>
-						<li>10-Mar-2016: change xml-roles mapping for doc-pagelist to reflect the actual role </li>
-                                              	<li>10-Mar-2016: Fix doc-prologue in table to not say doc-preface </li>
-                                              	<li>10-Mar-2016: Fix doc-conclusion to map to ROLE_LANDMARK for ATK/ATSPI </li>
-						<li>10-Mar-2016: changed doc-pagebreak to map to separator roles on IA2 and ATK/ATSPI </li>
-						<li>10-Mar-2016: modify doc-toc mapping to be consistent with doc-pagelist </li>
-						<li>10-Mar-2016: modify doc-subtitle to be a form of heading</li>
-						<li>10-Mar-2016: modify doc-pagebreak to be more like a separator</li>
-						<li>10-Mar-2016: Map doc-biblioentry and doc-endnote to ROLE_LIST_ITEM for ATK/ATSPI2; map doc-notice to ROLE_COMMENT for ATK/ATSPI2</li>
-						<li>14-Jul-2016: Remove special processing copied over from SVG-AAM for name and description computation.</li>
-						<li>26-Sep-2016: For macOS, modify doc-abstract, doc-acknowledgments, doc-afterword, doc-appendix, doc-bibliography, doc-chapter, doc-conclusion, doc-credits, doc-endnotes, doc-epilogue, doc-errata, doc-foreward, doc-glossary, doc-index, doc-introduction, doc-pagelist, doc-part, doc-pagebreak, doc-prologue, and doc-toc to be navigation or region landmarks.</li>
-						<li>28-Sep-2016: doc-abstract, doc-colophon, doc-credit, doc-dedication, doc-epigraph, doc-example and doc-qna are all to IA2_ROLE_SECTION; doc-notice, doc-tip mapped to IA2_ROLE_NOTE; convert a number of MSAA and IA2 roles to have &lt;code&gt; styling</li>
-
-
-                            			<!-- EdNote: After each WD publish, move contents of this list into the next one below.  -->
-                        		</ul>
-				</section>
-                	</section>
+    		<section class="appendix" id="changelog">
+    			<h2>Change Log</h2>
+        			
+    			<section id="recent-changes">
+    				<h2>Substantive changes since <a href="https://www.w3.org/TR/2017/REC-dpub-aam-1.0-20171214//">Digital Publishing Accessibility API Mappings 1.0</a></h2>
+    				<!-- EdNote: After each WD publish, move contents of this list into the next one below.  -->
+    				<ul>
+    					<li>20-Sep-2021: Added mappings for doc-pageheader and doc-pagefooter roles.</li>
+    				</ul>
+    			</section>
+    			<!-- uncomment after FPWD
+        		<section id="older-changes">
+        			<h2>Other substantive changes since <a href="https://www.w3.org/TR/2017/REC-dpub-aam-1.0-20171214//">Digital Publishing Accessibility API Mappings 1.0</a></h2>
+            		<ul>
+             		</ul>
+            	</section> -->
+			</section>
 			<section class="appendix informative section" id="acknowledgements">
 				<h3>Acknowledgments</h3>
 				<p>The following people contributed to the development of this document.</p>
 				<section class="section" id="ack_dpub">
-					<h4>Participants active in the DPUB-ARIA task force at the time of publication</h4>
+					<h3>Participants active in the DPUB-ARIA task force at the time of publication</h3>
 					<ul>
 						<li>Michael Cooper (W3C Staff)</li>
-						<li>Heather Flanagan (Invited expert)</li>
+						<li>Joanmarie Diggs (Igalia, S.L.)</li>
 						<li>Matt Garrish (DAISY Consortium)</li>
-						<li>Markus Gylling (DAISY Consortium)</li>
-						<li>Ivan Herman (W3C Staff)</li>
-						<li>Deborah Kaplan (Invited expert)</li>
-						<li>George Kerscher (DAISY Consortium)</li>
-						<li>Peter Krautzberger (W3C Invited Experts)</li>
-						<li>Charles LaPierre (Benetech)</li>
-						<li>Shane McCarron (W3C Invited Experts)</li>
-						<li>Janina Sajka (Invited Expert, The Linux Foundation)</li>
-						<li>Richard Schwerdtfeger (Knowbility)</li>
+						<li>James Nurthen (Adobe)</li>
 						<li>Tzviya Siegman (Wiley)</li>
 					</ul>
-					<p>The group would like to thank all members of the DAISY and EPUB 3 working groups who developed the structural semantics vocabulary from which this module was drawn, with special thanks to Sanders Kleinfeld for his assistance analyzing the initial set of semantics for inclusion.</p>
 				</section>
 				<div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
 			</section>


### PR DESCRIPTION
Just a bit of tidying to prepare the document for the next version:

- adds the revision number to document title
- updates the shortname with the new subversion number
- resets the change log and adds an entry for pageheader/pagefooter change
- updates the acknowledgements


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/pull/8.html" title="Last updated on Sep 23, 2021, 5:18 PM UTC (d62e110)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/8/a4de69c...d62e110.html" title="Last updated on Sep 23, 2021, 5:18 PM UTC (d62e110)">Diff</a>