### PR TITLE
Add mappings for implied biblioentry and endnote roles on list items

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,7 +387,25 @@ var mappingTableLabels = {
                                                                     AXRoleDescription: <code>'region'</code>
                                                                 </td>
                                                         </tr>
-                                                        <tr id="role-map-biblioref">
+														<tr id="role-map-biblioentry-implied">
+															<th><code>listitem</code> descendants of <a class="dpub-role-reference" href="#doc-bibliography"><code>doc-bibliography</code></a> (not descendant of another <code>listitem</code>)</th>
+								<td>
+									Expose
+									<p><code>ROLE_SYSTEM_LISTITEM</code> + <code>STATE_SYSTEM_READONLY</code></p>
+									<p>IAccessible2:</p><p>Object attribute <code>xml-roles:doc-biblioentry</code>.</p></td>
+								<td>
+									<ul>
+										<li>Control Type is <code>Text</code></li>
+										<li>Localized Control Type is '<code>biblioentry</code>'</li>
+									</ul>
+								</td>
+								<td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute <code>xml-roles:doc-bilioentry</code>.</p></td>
+								<td>AXRole: <code>AXGroup</code><br />
+									AXSubrole: <code>&lt;nil&gt;</code><br/>
+									AXRoleDescription: <code>'group'</code>
+								</td>
+							</tr>
+														<tr id="role-map-biblioref">
                                                                 <th><a class="dpub-role-reference" href="#doc-biblioref"><code>doc-biblioref</code></a></th>
 								<td>
                                                                         Expose
@@ -586,8 +604,25 @@ var mappingTableLabels = {
                                                                     AXRoleDescription: <code>'region'</code>
                                                                 </td>
                                                         </tr>
-
-                                                        <tr id="role-map-epigraph">
+														<tr id="role-map-endnote-implied">
+															<th><code>listitem</code> descendants of <a class="dpub-role-reference" href="#doc-endnotes"><code>doc-endnotes</code></a> (not descendant of another <code>listitem</code>)</th>
+								<td>
+									Expose
+									<p><code>ROLE_SYSTEM_LISTITEM</code> + <code>STATE_SYSTEM_READONLY</code></p>
+									<p>IAccessible2:</p><p>Object attribute <code>xml-roles:doc-endnote</code>.</p></td>
+								<td>
+									<ul>
+										<li>Control Type is <code>Text</code></li>
+										<li>Localized Control Type is '<code>endnote</code>'</li>
+									</ul>
+								</td>
+								<td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute <code>xml-roles:doc-endnote</code>. </p></td>
+								<td>AXRole: <code>AXGroup</code><br />
+									AXSubrole: <code>&lt;nil&gt;</code><br/>
+									AXRoleDescription: <code>'group'</code>
+								</td>
+							</tr>
+														<tr id="role-map-epigraph">
                                                                 <th><a class="dpub-role-reference" href="#doc-epigraph"><code>doc-epigraph</code></a></th>
                                                                 <td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute <code>xml-roles:doc-epigraph</code></td>
                                                                 <td>


### PR DESCRIPTION
Let me know if the titles I have for these mappings make sense. I was going to go with "Non-nested listitem descendants of ..." but it doesn't sound very clear since even the list items that are implied will be nested to some level in other markup. I'm not sure how to make what I have any less wordy, though.

The rest of the mappings are straight copies of the doc-biblioentry/doc-endnote roles.

I'll add a change log entry for this after its merged, as I branched this off main instead of the other PR I opened to clean up that section.