### PR TITLE
Fix reference to wrong role

### DIFF
--- a/index.html
+++ b/index.html
@@ -1207,7 +1207,7 @@ var mappingTableLabels = {
 									</ul>
 								</td>
 								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-pagebreak</code>. </p></td>
+											<code>xml-roles:doc-preface</code>. </p></td>
 								<td>
 									<ul>
 										<li>AXRole: <code>AXGroup</code></li>
@@ -1429,6 +1429,8 @@ var mappingTableLabels = {
 							>Digital Publishing Accessibility API Mappings 1.0</a></h2>
 					<!-- EdNote: After each WD publish, move contents of this list into the next one below.  -->
 					<ul>
+						<li>4-Jan-2022: Fix incorrect doc-pagebreak role mentioned in ATK/AT-SPI mapping for doc-preface.</li>
+						<li>4-Jan-2022: Updated Mac AX API mappings to add AXCustomContent fields.</li>
 						<li>20-Sep-2021: Added mappings for doc-pageheader and doc-pagefooter roles.</li>
 					</ul>
 				</section>


### PR DESCRIPTION
Corrects the reference to doc-pagebreak in the ATK/AT-SPI mapping for doc-preface.

@clapierre I can't request a formal review from you, so can you just confirm this fix in the comments.

Fixes #16 