### PR TITLE
Add that AXRoleDescription and AXCustomContent value are localizable strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,9 +262,6 @@
 					Elements having roles with a prefix value of <code>doc-</code>, that are not listed in this role
 					mapping table, have no normative mappings.</p>
 
-				<p class="note">There are a number of roles mappings that are localized. The group needs to look into
-					localizing for non-English languages.</p>
-
 				<div class="table-container">
 					<table class="map-table elements" id="role-mapping-table">
 						<caption>Table describing mapping of <abbr title="Accessible Rich Internet Applications"
@@ -1407,12 +1404,19 @@
 						</tbody>
 					</table>
 				</div>
-				<div class="note" id="ftn.note1">
-					<p>
-						<sup>[Note 1]</sup> User agents should return a user-presentable, localized string for the
-						AXRoleDescription and the AXCustomContent <code>value</code>.</p>
-				</div>
 			</section>
+		</section>
+		<section id="translatable-values">
+			<h2>Translatable Values</h2>
+
+			<p>The HTML specification states that other specifications can define translatable attributes. The language
+				and directionality of each attribute value is the same as the language and directionality of the
+				element.</p>
+
+			<p>To be understandable by assistive technology users, <code>role</code> mapping values intended for human
+				consumption should be translated when a page is localized. These include the AXRoleDescription and the
+					<code>value</code> field of AXCustomContent for Mac AX API, and the Localized Control Type and
+				Landmark Type for UIA.</p>
 		</section>
 		<section id="mapping_state-property">
 			<h2>State and Property Mapping</h2>

--- a/index.html
+++ b/index.html
@@ -1498,8 +1498,7 @@
 					<!-- EdNote: After each WD publish, move contents of this list into the next one below.  -->
 
 					<ul>
-						<li>06-Jan-2023: Added note that AXRoleDescription and AXCustomContent <code>value</code> are
-							localizable strings.</li>
+						<li>10-Jan-2023: Added section on translatable values.</li>
 						<li>04-Jan-2023: Fixed incorrect doc-pagebreak role mentioned in ATK/AT-SPI mapping for
 							doc-preface.</li>
 						<li>04-Jan-2023: Fixed incorrect doc-pagebreak role mentioned in ATK/AT-SPI mapping for

--- a/index.html
+++ b/index.html
@@ -1433,6 +1433,7 @@ var mappingTableLabels = {
 							>Digital Publishing Accessibility API Mappings 1.0</a></h2>
 					<!-- EdNote: After each WD publish, move contents of this list into the next one below.  -->
 					<ul>
+						<li>06-Jan-2023: Added note that AXRoleDescription and AXCustomContent <code>value</code> are localizable strings.</li>
 						<li>04-Jan-2023: Fixed incorrect doc-pagebreak role mentioned in ATK/AT-SPI mapping for doc-preface.</li>
 						<li>04-Jan-2023: Updated Mac AX API mappings to add AXCustomContent fields.</li>
 						<li>20-Sep-2021: Added mappings for doc-pageheader and doc-pagefooter roles.</li>

--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@ var mappingTableLabels = {
 								<th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr
 										title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
 									Role</th>
-								<th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+								<th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr><sup>[<a href="#ftn.note1">Note 1</a>]</sup></th>
 							</tr>
 						</thead>
 						<tbody>
@@ -305,7 +305,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "acknowledgements" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "acknowledgements" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -333,7 +333,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "afterword" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "afterword" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -361,7 +361,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "appendix" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "appendix" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -391,7 +391,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXLink</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'link'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "back" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "back" }</code></li>
 									</ul>
 								</td>
 
@@ -417,7 +417,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{}</code></li><!-- intentionally blank b/c these are already contained by the 'bibliography' region -->
+										<li>AXCustomContent: <code>{}</code></li><!-- intentionally blank b/c these are already contained by the 'bibliography' region -->
 									</ul>
 								</td>
 							</tr>
@@ -444,7 +444,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "bibliography" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "bibliography" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -469,7 +469,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{}</code></li><!-- intentionally blank b/c these are already contained by the 'bibliography' region -->
+										<li>AXCustomContent: <code>{}</code></li><!-- intentionally blank b/c these are already contained by the 'bibliography' region -->
 									</ul>
 								</td>
 							</tr>
@@ -499,7 +499,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXLink</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'link'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "bibliography" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "bibliography" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -526,7 +526,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkChapter</code></li>
 										<li>AXRoleDescription: <code>'chapter'</code></li>
-										<li>AXCustomContent:<code>{}</code></li><!-- intentionally blank -->
+										<li>AXCustomContent: <code>{}</code></li><!-- intentionally blank -->
 									</ul>
 								</td>
 							</tr>
@@ -548,7 +548,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXApplicationGroup</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "colophon" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "colophon" }</code></li>
 									</ul>
 								</td>
 
@@ -576,7 +576,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "conclusion" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "conclusion" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -596,7 +596,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXImage</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'cover image'</code></li>
-										<li>AXCustomContent:<code>{}</code></li><!-- intentionally blank -->
+										<li>AXCustomContent: <code>{}</code></li><!-- intentionally blank -->
 									</ul>
 								</td>
 							</tr>
@@ -617,7 +617,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXApplicationGroup</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{}</code></li><!-- intentionally blank b/c this is already contained by 'credits' -->
+										<li>AXCustomContent: <code>{}</code></li><!-- intentionally blank b/c this is already contained by 'credits' -->
 									</ul>
 								</td>
 							</tr>
@@ -643,7 +643,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "credits" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "credits" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -665,7 +665,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXApplicationGroup</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "dedication" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "dedication" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -687,7 +687,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{}</code></li><!-- intentionally blank b/c this is already contained by 'endnotes' -->
+										<li>AXCustomContent: <code>{}</code></li><!-- intentionally blank b/c this is already contained by 'endnotes' -->
 									</ul>
 								</td>
 							</tr>
@@ -715,7 +715,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "end notes" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "end notes" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -739,7 +739,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{}</code></li><!-- intentionally blank b/c this is already contained by 'endnotes' -->
+										<li>AXCustomContent: <code>{}</code></li><!-- intentionally blank b/c this is already contained by 'endnotes' -->
 									</ul>
 								</td>
 							</tr>
@@ -761,7 +761,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXApplicationGroup</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "epigraph" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "epigraph" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -788,7 +788,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "epilog" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "epilog" }</code></li>
 									</ul>
 								</td>
 
@@ -815,7 +815,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "errata" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "errata" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -836,7 +836,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXApplicationGroup</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "example" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "example" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -862,7 +862,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXApplicationGroup</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "footnote" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "footnote" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -889,7 +889,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "foreword" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "foreword" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -917,7 +917,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "glossary" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "glossary" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -947,7 +947,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXLink</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'link'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "glossary" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "glossary" }</code></li>
 									</ul>
 								</td>
 
@@ -975,7 +975,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkNavigation</code></li>
 										<li>AXRoleDescription: <code>'navigation'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "index" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "index" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1003,7 +1003,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "introduction" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "introduction" }</code></li>
 									</ul>
 								</td>
 
@@ -1033,7 +1033,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXLink</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'link'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "note" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "note" }</code></li>
 									</ul>
 								</td>
 
@@ -1055,7 +1055,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXDocumentNote</code></li>
 										<li>AXRoleDescription: <code>'note'</code></li>
-										<li>AXCustomContent:<code>{}</code></li><!-- intentionally blank -->
+										<li>AXCustomContent: <code>{}</code></li><!-- intentionally blank -->
 									</ul>
 								</td>
 							</tr>
@@ -1077,7 +1077,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXSplitter</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'splitter'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "page break" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "page break" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1104,7 +1104,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "footer" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "footer" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1131,7 +1131,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "header" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "header" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1159,7 +1159,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkNavigation</code></li>
 										<li>AXRoleDescription: <code>'navigation'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "page list" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "page list" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1186,7 +1186,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "part" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "part" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1213,7 +1213,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "preface" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "preface" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1241,7 +1241,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
 										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "prolog" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "prolog" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1267,7 +1267,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXApplicationGroup</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "pull quote" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "pull quote" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1288,7 +1288,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXApplicationGroup</code></li>
 										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "Q&amp;A" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "Q&amp;A" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1313,7 +1313,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXHeading</code></li>
 										<li>AXSubrole: <code>AXSubtitle</code></li>
 										<li>AXRoleDescription: <code>'subtitle'</code></li>
-										<li>AXCustomContent:<code>{}</code></li><!-- intentionally blank -->
+										<li>AXCustomContent: <code>{}</code></li><!-- intentionally blank -->
 									</ul>
 								</td>
 							</tr>
@@ -1335,7 +1335,7 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXDocumentNote</code></li>
 										<li>AXRoleDescription: <code>'note'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "tip" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "tip" }</code></li>
 									</ul>
 								</td>
 							</tr>
@@ -1362,12 +1362,16 @@ var mappingTableLabels = {
 										<li>AXRole: <code>AXGroup</code></li>
 										<li>AXSubrole: <code>AXLandmarkNavigation</code></li>
 										<li>AXRoleDescription: <code>'navigation'</code></li>
-										<li>AXCustomContent:<code>{ label: "type", value: "table of contents" }</code></li>
+										<li>AXCustomContent: <code>{ label: "type", value: "table of contents" }</code></li>
 									</ul>
 								</td>
 							</tr>
 						</tbody>
 					</table>
+				</div>
+				<div class="note" id="ftn.note1"><p>
+					<sup>[Note 1]</sup>
+					User agents should return a user-presentable, localized string for the AXRoleDescription and the AXCustomContent <code>value</code>.</p>
 				</div>
 			</section>
 		</section>

--- a/index.html
+++ b/index.html
@@ -276,8 +276,7 @@
 								<th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr
 										title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
 									Role</th>
-								<th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr><sup>[<a
-											href="#ftn.note1">Note 1</a>]</sup></th>
+								<th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
 							</tr>
 						</thead>
 						<tbody>
@@ -1409,14 +1408,20 @@
 		<section id="translatable-values">
 			<h2>Translatable Values</h2>
 
-			<p>The HTML specification states that other specifications can define translatable attributes. The language
-				and directionality of each attribute value is the same as the language and directionality of the
-				element.</p>
+			<p>The HTML specification states that other specifications can define <a
+					data-cite="html#translatable-attributes">translatable attributes</a> [[html]]. The language and
+				directionality of each attribute value is the same as the <a data-cite="html#language">language</a> and
+					<a data-cite="html#the-direction">directionality</a> of the element [[html]].</p>
 
-			<p>To be understandable by assistive technology users, <code>role</code> mapping values intended for human
-				consumption should be translated when a page is localized. These include the AXRoleDescription and the
-					<code>value</code> field of AXCustomContent for Mac AX API, and the Localized Control Type and
-				Landmark Type for UIA.</p>
+			<p>To be understandable by assistive technology users, the following <code>role</code> mapping values
+				intended for human consumption should be translated when a page is localized:</p>
+
+			<ul>
+				<li>AXRoleDescription</li>
+				<li>the <code>value</code> property of AXCustomContent</li>
+				<li>Localized Control Type</li>
+				<li>Localized Landmark Type</li>
+			</ul>
 		</section>
 		<section id="mapping_state-property">
 			<h2>State and Property Mapping</h2>


### PR DESCRIPTION
Adds the modified version of the note from core-aam specification described in https://github.com/w3c/dpub-aam/issues/18#issuecomment-1372722694

Also adds a space after the "AXCustomContent" label in the tables.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/pull/20.html" title="Last updated on Jan 13, 2023, 3:30 PM UTC (9d9be09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/20/f500b9d...9d9be09.html" title="Last updated on Jan 13, 2023, 3:30 PM UTC (9d9be09)">Diff</a>