### PR TITLE
Remove widget values section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1430,14 +1430,6 @@
 					specification.</p>
 			</section>
 
-			<section id="mapping_additional_widget-value">
-				<h3>Widget Values</h3>
-
-				<p>User agents <span class="rfc2119">MUST</span> conform to the <a
-						href="#mapping_additional_widget-value" class="core-mapping">Widget Values</a> accessibility API
-					computational requirements in [[!CORE-AAM-1.1]].</p>
-			</section>
-
 			<section id="mapping_additional_relations">
 				<h3>Relations</h3>
 


### PR DESCRIPTION
Removing the section for the same reason it was removed from core-aam.

See https://github.com/w3c/core-aam/commit/eecb5af7e130134337d6a101a3dbac7db4780ced

Fixes #19


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/pull/25.html" title="Last updated on Jan 13, 2023, 2:16 PM UTC (4401041)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/25/58abc6f...4401041.html" title="Last updated on Jan 13, 2023, 2:16 PM UTC (4401041)">Diff</a>