### PR TITLE
Move abstract prose to introduction

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,6 +154,13 @@
 						title="Application Programming Interfaces">APIs</abbr></a>. It is intended for user agent
 				developers responsible for accessibility in their user agent so that they can support the accessibility
 				content produced for digital publishing.</p>
+		</section>
+		<section id="sotd">
+			<p>For a complete list of changes addressed in this revision, please refer to the <a href="#changelog"
+					>change log</a>.</p>
+		</section>
+		<section id="intro" class="informative">
+			<h2>Introduction</h2>
 
 			<p>The implementation of this specification in user agents enables authors to produce more accessible
 				e-books, by conveying structural book constructs used by the digital publishing industry to assistive
@@ -166,13 +173,6 @@
 			<p>The DPub-AAM is part of the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> suite
 				described in the <a href="http://www.w3.org/WAI/intro/aria.php"><abbr
 						title="Accessible Rich Internet Application">WAI-ARIA</abbr> Overview</a>.</p>
-		</section>
-		<section id="sotd">
-			<p>For a complete list of changes addressed in this revision, please refer to the <a href="#changelog"
-					>change log</a>.</p>
-		</section>
-		<section id="intro" class="informative">
-			<h2>Introduction</h2>
 		</section>
 		<section id="conformance" class="normative">
 			<p>This specification indicates whether a section is normative or informative and the classification applies


### PR DESCRIPTION
Looking into #21, it appears our abstract ate our introduction.

This pull request simply moves the last two paragraphs of the abstract into the introduction, making the abstract less verbose and giving enough an introduction for this document's purposes.

Fixes #21


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/pull/26.html" title="Last updated on Jan 13, 2023, 2:40 PM UTC (3085d11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/26/58abc6f...3085d11.html" title="Last updated on Jan 13, 2023, 2:40 PM UTC (3085d11)">Diff</a>