### PR TITLE
Add deprecated features section

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,29 +175,41 @@
 			<h2>Introduction</h2>
 		</section>
 		<section id="conformance" class="normative">
-			<p>This specification indicates whether a section is normative or informative and the classification applies
-				to the entire section. A statement "This section is normative" or "This section is informative" applies
-				to all sub-sections of that section.</p>
 
-			<p>Normative sections provide requirements that [=user agents=] must follow for an implementation to conform
-				to this specification. The keywords <strong class="rfc2119">MUST</strong>, <strong class="rfc2119">MUST
-					NOT</strong>, <strong class="rfc2119">REQUIRED</strong>, <strong class="rfc2119">SHALL</strong>,
-					<strong class="rfc2119">SHALL NOT</strong>, <strong class="rfc2119">SHOULD</strong>, <strong
-					class="rfc2119">RECOMMENDED</strong>, <strong class="rfc2119">MAY</strong>, and <strong
-					class="rfc2119">OPTIONAL</strong> in this document are to be interpreted as described in <cite><a
-						href="http://www.rfc-editor.org/rfc/rfc2119.txt">Keywords for use in RFCs to indicate
-						requirement levels</a></cite> [[!RFC2119]]. RFC-2119 keywords are formatted in uppercase and
-				contained in a <code>strong</code> element with <code>class="rfc2119"</code>. When the keywords shown
-				above are used, but do not share this format, they do not convey formal information in the RFC 2119
-				sense, and are merely explanatory, i.e., informative. As much as possible, such usages are avoided in
-				this specification.</p>
+			<section id="rfc-2119-keywords">
+				<h3>RFC-2119 Keywords</h3>
 
-			<p>Informative sections provide information useful to understanding the specification. Such sections may
-				contain examples of recommended practice, but it is not required to follow such recommendations in order
-				to conform to this specification.</p>
+				<p>RFC-2119 keywords are formatted in uppercase and contained in a <code>strong</code> element with
+						<code>class="rfc2119"</code>. When the keywords shown above are used, but do not share this
+					format, they do not convey formal information in the RFC 2119 sense, and are merely explanatory
+					(i.e., informative). As much as possible, such usages are avoided in this specification.</p>
+			</section>
+
+			<section id="normative-and-informative-sections">
+				<h3>Normative and Informative Sections</h3>
+
+				<p>The indication whether a section is normative or non-normative (informative) applies to the entire
+					section including sub-sections.</p>
+
+				<p>Informative sections provide information useful to understanding the specification. Such sections may
+					contain examples of recommended practice, but it is not required to follow such recommendations in
+					order to conform to this specification.</p>
+			</section>
+
+			<section id="dpub-deprecated-roles">
+				<h3>Roles deprecated in DPUB-ARIA</h3>
+
+				<p>The DPUB-ARIA specification [[dpub-aria-1.1]] lists some roles as deprecated. Although this means
+					authors are encouraged not to use these roles, it is expected that the roles could still be used in
+					legacy content. Therefore, it is important that user agents continue to map these roles to
+					accessibility APIs, and doing so is part of conformance to this specification. When future versions
+					of the DPUB-ARIA specification change such roles from deprecated to removed, they will be removed
+					from the mappings as well and user agents will no longer be asked to continue support for those
+					roles.</p>
+			</section>
 		</section>
 		<section class="section" id="keyboard-focus">
-			<h2>Supporting Keyboard Navigation</h2>
+			<h2>Supporting keyboard navigation</h2>
 
 			<p>Enabling keyboard navigation in web applications is a necessary step toward making accessible web
 				applications possible. Conforming [=user agents=] <span class="rfc2119">MUST</span> conform to <a
@@ -205,7 +217,7 @@
 				[[!CORE-AAM-1.1]].</p>
 		</section>
 		<section id="mapping">
-			<h2>Mapping <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> to Accessibility <abbr
+			<h2>Mapping <abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> to accessibility <abbr
 					title="Application Programming Interfaces">APIs</abbr></h2>
 
 			<section id="mapping_general">


### PR DESCRIPTION
I've just copied over the conformance section from core-aam in this pull request and tweaked section 2.3 so that it talks about deprecated DPUB roles instead of deprecated ARIA features.

Fixes #22


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/pull/27.html" title="Last updated on Jan 13, 2023, 3:07 PM UTC (234e4ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/27/58abc6f...234e4ed.html" title="Last updated on Jan 13, 2023, 3:07 PM UTC (234e4ed)">Diff</a>