### PR TITLE
The ARIA WG is now operating under the "W3C Software and Document Licence"

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 			    // if you wish the publication date to be other than today, set this
 			    // publishDate:  "2009-08-06",
 			    copyrightStart:  "2015",
-			    license: "document",
+			    license: "w3c-software-doc",
 			
 			    // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
 			    // and its maturity status


### PR DESCRIPTION
The license used is not the one specified in the WG's charter. This makes echidna reject the document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/pull/28.html" title="Last updated on Mar 8, 2023, 7:47 AM UTC (00d08ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/28/740e8b0...00d08ef.html" title="Last updated on Mar 8, 2023, 7:47 AM UTC (00d08ef)">Diff</a>