### PR TITLE
Remove mapping table and summary/details in favor of sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
 		<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="common/script/resolveReferences.js" class="remove"></script>
-		<script src="common/script/mapping-tables.js"></script>
 		<link href="common/css/mapping-tables.css" rel="stylesheet" type="text/css" />
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
 		<!--<link href="css/dpub-aam.css" rel="stylesheet" type="text/css"/>-->
@@ -153,7 +152,7 @@
 			      "CR": "https://www.w3.org/TR/accname-1.2/",
 			      "REC": "https://www.w3.org/TR/accname-1.2/"
 			    },
-			    preProcess: [ linkCrossReferences, mappingTables ],
+			    preProcess: [ linkCrossReferences ],
 			    postProcess: [ ],
 			    xref: ["core-aam", "wai-aria", "dom", "infra", "accname"],
 			    lint: {
@@ -162,25 +161,6 @@
 			  }
 		</script>
 		<script src="common/biblio.js" class="remove"></script>
-		<script type="text/javascript">
-			var mappingTableLabels = {
-			  viewByTable: "View as a single table",
-			  expand: "Expand all",
-			  collapse: "Collapse all",
-			  showHideCols: "Show/Hide Columns:",
-			  showActionText: "Show",
-			  hideActionText: "Hide",
-			  showToolTipText: "Show column",
-			  hideToolTipText: "Hide column",
-			
-			  // map where keys are @id of associated mapping table:
-			  viewByLabels: {
-			    "role-mapping-table": "View by roles",
-			    "state-property-mapping-table": "View by state/property",
-			    "event-mapping-table": "View by state/property"
-			  }
-			}
-		</script>
 	</head>
 	<body>
 		<section id="abstract">
@@ -306,7 +286,7 @@
 			</section>
 
 			<section id="mapping_role_table">
-				<h3>Role Mapping Table</h3>
+				<h3>Role Mapping Tables</h3>
 
 				<p class="note">Translators: For label text associated with the following table and its toggle buttons,
 					see the <code>mappingTableLabels</code> object in the <code>&lt;head&gt;</code> section of this
@@ -316,1147 +296,2222 @@
 					Elements having roles with a prefix value of <code>doc-</code>, that are not listed in this role
 					mapping table, have no normative mappings.</p>
 
-				<div class="table-container">
-					<table class="map-table elements" id="role-mapping-table">
-						<caption>Table describing mapping of <abbr title="Accessible Rich Internet Applications"
-								>WAI-ARIA</abbr> roles to accessibility <abbr title="application programming interfaces"
-								>APIs</abbr>.</caption>
-						<thead>
-							<tr>
-								<th><abbr title="Accessible Rich Internet Application">WAI-ARIA</abbr> Role</th>
-								<th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
-								<th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
-									Features</th>
-								<th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr
-										title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
-									Role</th>
-								<th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr id="role-map-abstract">
-								<th><a class="dpub-role-reference" href="#doc-abstract"
-									><code>doc-abstract</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_SECTION</code></li>
-										<li>Object attribute <code>xml-roles:doc-abstract</code>. </li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>abstract</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_SECTION</code> and object attribute
-											<code>xml-roles:doc-abstract</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXApplicationGroup</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "abstract" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-acknowledgments">
-								<th><a class="dpub-role-reference" href="#doc-acknowledgments"
-											><code>doc-acknowledgments</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-acknowledgments</code>. </li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>acknowledgements</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>acknowledgements</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code><code>ROLE_LANDMARK</code></code> and object attribute
-											<code>xml-roles:doc-acknowledgments</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "acknowledgements"
-											}</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-afterword">
-								<th><a class="dpub-role-reference" href="#doc-afterword"
-									><code>doc-afterword</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-afterword</code>. </li>
-									</ul>
-								</td>
-
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>afterword</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>afterword</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-afterword</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "afterword" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-appendix">
-								<th><a class="dpub-role-reference" href="#doc-appendix"
-									><code>doc-appendix</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-appendix</code>. </li>
-									</ul>
-								</td>
-
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>appendix</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>appendix</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-appendix</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "appendix" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-backlink">
-								<th><a class="dpub-role-reference" href="#doc-backlink"
-									><code>doc-backlink</code></a></th>
-								<td> Expose <ul>
-										<li><code>ROLE_SYSTEM_LINK</code> + <code>STATE_LINKED</code></li>
-										<li><code>STATE_LINKED</code> on all descendants</li>
-									</ul>
-									<p>IAccessible2:</p>
-									<ul>
-										<li>Object attribute <code>xml-roles:doc-backlink</code>.</li>
-										<li><code>AccessibleHypertext</code> interface</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>backlink</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LINK</code> and object attribute
-											<code>xml-roles:doc-backlink</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXLink</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'link'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "back" }</code></li>
-									</ul>
-								</td>
-
-							</tr>
-
-							<tr id="role-map-biblioentry">
-								<th><a class="dpub-role-reference" href="#doc-biblioentry"
-										><code>doc-biblioentry</code></a></th>
-								<td> Expose <p><code>ROLE_SYSTEM_LISTITEM</code> +
-										<code>STATE_SYSTEM_READONLY</code></p>
-									<p>IAccessible2:</p><p>Object attribute
-									<code>xml-roles:doc-biblioentry</code>.</p></td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>biblioentry</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute
-											<code>xml-roles:doc-bilioentry</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{}</code></li>
-										<!-- intentionally blank b/c these are already contained by the 'bibliography' region -->
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-bibliography">
-								<th><a class="dpub-role-reference" href="#doc-biblioentry"
-										><code>doc-bibliography</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-bibliography</code>. </li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>bibliography</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>biblography</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-bibliography</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "bibliography" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-biblioentry-implied">
-								<th><code>listitem</code> descendants of <a class="dpub-role-reference"
-										href="#doc-bibliography"><code>doc-bibliography</code></a> (not descendant of
-									another <code>listitem</code>)</th>
-								<td> Expose <p><code>ROLE_SYSTEM_LISTITEM</code> +
-										<code>STATE_SYSTEM_READONLY</code></p>
-									<p>IAccessible2:</p><p>Object attribute
-									<code>xml-roles:doc-biblioentry</code>.</p></td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>biblioentry</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute
-											<code>xml-roles:doc-bilioentry</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{}</code></li>
-										<!-- intentionally blank b/c these are already contained by the 'bibliography' region -->
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-biblioref">
-								<th><a class="dpub-role-reference" href="#doc-biblioref"
-									><code>doc-biblioref</code></a></th>
-								<td> Expose <ul>
-										<li><code>ROLE_SYSTEM_LINK</code> + <code>STATE_LINKED</code></li>
-										<li><code>STATE_LINKED</code> on all descendants</li>
-									</ul>
-									<p>IAccessible2:</p>
-									<ul>
-										<li>Object attribute <code>xml-roles:doc-biblioref</code>.</li>
-										<li><code>AccessibleHypertext</code> interface</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>biblioref</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LINK</code> and object attribute
-											<code>xml-roles:doc-biblioref</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXLink</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'link'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "bibliography" }</code></li>
-									</ul>
-								</td>
-							</tr>
-
-							<tr id="role-map-chapter">
-								<th><a class="dpub-role-reference" href="#doc-chapter"><code>doc-chapter</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-chapter</code>. </li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>chapter</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>chapter</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:chapter</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkChapter</code></li>
-										<li>AXRoleDescription: <code>'chapter'</code></li>
-										<li>AXCustomContent: <code>{}</code></li>
-										<!-- intentionally blank -->
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-colophon">
-								<th><a class="dpub-role-reference" href="#doc-colophon"
-									><code>doc-colophon</code></a></th>
-								<td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2: Object attribute
-											<code>xml-roles:doc-colophon</code>.</p></td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>colophon</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_SECTION</code> and object attribute
-											<code>xml-roles:doc-colophon</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXApplicationGroup</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "colophon" }</code></li>
-									</ul>
-								</td>
-
-							</tr>
-							<tr id="role-map-conclusion">
-								<th><a class="dpub-role-reference" href="#doc-conclusion"
-										><code>doc-conclusion</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-conclusion</code>. </li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>conclusion</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>conclusion</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-conclusion</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "conclusion" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-cover">
-								<th><a class="dpub-role-reference" href="#doc-cover"><code>doc-cover</code></a></th>
-								<td>Expose <p><code>ROLE_SYSTEM_GRAPHIC</code></p>
-									<p>IAccessible2: Object attribute <code>xml-roles:doc-cover</code>.</p>
-								</td>
-								<td>Control Type is <code>Image</code>
-								</td>
-								<td>
-									<p>expose <code>ROLE_IMAGE</code> and object attribute
-											<code>xml-roles:doc-cover</code>.</p>
-								</td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXImage</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'cover image'</code></li>
-										<li>AXCustomContent: <code>{}</code></li>
-										<!-- intentionally blank -->
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-credit">
-								<th><a class="dpub-role-reference" href="#doc-cover"><code>doc-credit</code></a></th>
-								<td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute
-										<code>xml-roles:doc-credit</code></td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>credit</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_SECTION</code> and object attribute
-											<code>xml-roles:doc-credit</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXApplicationGroup</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{}</code></li>
-										<!-- intentionally blank b/c this is already contained by 'credits' -->
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-credits">
-								<th><a class="dpub-role-reference" href="#doc-credits"><code>doc-credits</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-credits</code>. </li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>credits</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>credits</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-credits</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "credits" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-dedication">
-								<th><a class="dpub-role-reference" href="#doc-dedication"
-										><code>doc-dedication</code></a></th>
-								<td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute
-										<code>xml-roles:doc-dedication</code></td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>dedication</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_SECTION</code> and object attribute
-											<code>xml-roles:doc-dedication</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXApplicationGroup</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "dedication" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-endnote">
-								<th><a class="dpub-role-reference" href="#doc-endnote"><code>doc-endnote</code></a></th>
-								<td> Expose <p><code>ROLE_SYSTEM_LISTITEM</code> +
-										<code>STATE_SYSTEM_READONLY</code></p>
-									<p>IAccessible2:</p><p>Object attribute <code>xml-roles:doc-endnote</code>.</p></td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>endnote</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute
-											<code>xml-roles:doc-endnote</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{}</code></li>
-										<!-- intentionally blank b/c this is already contained by 'endnotes' -->
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-endnotes">
-								<th><a class="dpub-role-reference" href="#doc-endnote"
-									><code>doc-endnotes</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-endnotes</code>. </li>
-									</ul>
-								</td>
-
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>endnotes</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>endnotes</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-endnotes</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "end notes" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-endnote-implied">
-								<th><code>listitem</code> descendants of <a class="dpub-role-reference"
-										href="#doc-endnotes"><code>doc-endnotes</code></a> (not descendant of another
-										<code>listitem</code>)</th>
-								<td> Expose <p><code>ROLE_SYSTEM_LISTITEM</code> +
-										<code>STATE_SYSTEM_READONLY</code></p>
-									<p>IAccessible2:</p><p>Object attribute <code>xml-roles:doc-endnote</code>.</p></td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>endnote</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LIST_ITEM</code> and object attribute
-											<code>xml-roles:doc-endnote</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{}</code></li>
-										<!-- intentionally blank b/c this is already contained by 'endnotes' -->
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-epigraph">
-								<th><a class="dpub-role-reference" href="#doc-epigraph"
-									><code>doc-epigraph</code></a></th>
-								<td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute
-										<code>xml-roles:doc-epigraph</code></td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>epigraph</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_SECTION</code> and object attribute
-											<code>xml-roles:doc-epigraph</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXApplicationGroup</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "epigraph" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-epilogue">
-								<th><a class="dpub-role-reference" href="#doc-epilogue"
-									><code>doc-epilogue</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-epilogue</code>. </li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>epilogue</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>epilogue</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-epilogue</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "epilog" }</code></li>
-									</ul>
-								</td>
-
-							</tr>
-							<tr id="role-map-errata">
-								<th><a class="dpub-role-reference" href="#doc-cover"><code>doc-errata</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-errata</code></li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>errata</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>errata</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-errata</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "errata" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-example">
-								<th><a class="dpub-role-reference" href="#doc-cover"><code>doc-example</code></a></th>
-								<td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute
-										<code>xml-roles:doc-example</code></td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>example</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_SECTION</code> and object attribute
-											<code>xml-roles:doc-example</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXApplicationGroup</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "example" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-footnote">
-								<th><a class="dpub-role-reference" href="#doc-footnote"
-									><code>doc-footnote</code></a></th>
-								<td><p>Expose IAccessible2:</p>
-									<ul>
-										<li><code>IA2_ROLE_FOOTNOTE</code></li>
-										<li>Object attribute: <code>xml-roles:doc-footnote</code></li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>footnote</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_FOOTNOTE</code> and object attribute
-											<code>xml-roles:doc-footnote</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXApplicationGroup</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "footnote" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-foreword">
-								<th><a class="dpub-role-reference" href="#doc-foreword"
-									><code>doc-foreword</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-foreword</code></li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>foreword</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>foreword</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-foreword</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "foreword" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-glossary">
-								<th><a class="dpub-role-reference" href="#doc-glossary"
-									><code>doc-glossary</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-glossary</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>glossary</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>glossary</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-glossary</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "glossary" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-glossref">
-								<th><a class="dpub-role-reference" href="#doc-glossref"
-									><code>doc-glossref</code></a></th>
-								<td> Expose <ul>
-										<li><code>ROLE_SYSTEM_LINK</code> + <code>STATE_LINKED</code></li>
-										<li><code>STATE_LINKED</code> on all descendants</li>
-									</ul>
-									<p>IAccessible2:</p>
-									<ul>
-										<li>Object attribute <code>xml-roles:doc-glossref</code>.</li>
-										<li><code>AccessibleHypertext</code> interface</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>glossref</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LINK</code> and object attribute
-											<code>xml-roles:doc-glossref</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXLink</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'link'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "glossary" }</code></li>
-									</ul>
-								</td>
-
-							</tr>
-							<tr id="role-map-index">
-								<th><a class="dpub-role-reference" href="#doc-index"><code>doc-index</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-index</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>index</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>index</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-index</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkNavigation</code></li>
-										<li>AXRoleDescription: <code>'navigation'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "index" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-introduction">
-								<th><a class="dpub-role-reference" href="#doc-introduction"
-											><code>doc-introduction</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-introduction</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>introduction</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>introduction</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-introduction</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "introduction" }</code></li>
-									</ul>
-								</td>
-
-							</tr>
-							<tr id="role-map-noteref">
-								<th><a class="dpub-role-reference" href="#doc-noteref"><code>doc-noteref</code></a></th>
-								<td> Expose <ul>
-										<li><code>ROLE_SYSTEM_LINK</code> + <code>STATE_LINKED</code></li>
-										<li><code>STATE_LINKED</code> on all descendants</li>
-									</ul>
-									<p>IAccessible2:</p>
-									<ul>
-										<li>Object attribute <code>xml-roles:doc-noteref</code>.</li>
-										<li><code>AccessibleHypertext</code> interface</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>noteref</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LINK</code> and object attribute
-											<code>xml-roles:doc-noteref</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXLink</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'link'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "note" }</code></li>
-									</ul>
-								</td>
-
-							</tr>
-							<tr id="role-map-notice">
-								<th><a class="dpub-role-reference" href="#doc-notice"><code>doc-notice</code></a></th>
-								<td>Expose <p><code>IA2_ROLE_NOTE</code></p>
-									<p>IAccessible2:</p> Object attribute <code>xml-roles:doc-notice</code>.</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>notice</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_COMMENT</code> and object attribute
-											<code>xml-roles:doc-notice</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXDocumentNote</code></li>
-										<li>AXRoleDescription: <code>'note'</code></li>
-										<li>AXCustomContent: <code>{}</code></li>
-										<!-- intentionally blank -->
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-pagebreak">
-								<th><a class="dpub-role-reference" href="#doc-pagebreak"
-									><code>doc-pagebreak</code></a></th>
-								<td>Expose <p><code>ROLE_SYSTEM_SEPARATOR</code></p>
-									<p>IAccessible2:</p> Object attribute <code>xml-roles:doc-pagebreak</code>. </td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>pagebreak</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_SEPARATOR</code> and object attribute
-											<code>xml-roles:doc-pagebreak</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXSplitter</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'splitter'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "page break" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-pagefooter">
-								<th><a class="dpub-role-reference" href="#doc-pagefooter"
-										><code>doc-pagefooter</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_FOOTER</code></li>
-										<li>Object attribute <code>xml-roles:doc-pagefooter</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Control Pattern: <code>Annotation</code></li>
-										<li><code>Annotation.AnnotationTypeId</code>: <code>Footer</code></li>
-									</ul>
-								</td>
-								<td>Expose <p><code>ROLE_FOOTER</code> and object attribute
-											<code>xml-roles:doc-pagefooter</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "footer" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-pageheader">
-								<th><a class="dpub-role-reference" href="#doc-pageheader"
-										><code>doc-pageheader</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_HEADER</code></li>
-										<li>Object attribute <code>xml-roles:doc-pageheader</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Control Pattern: <code>Annotation</code></li>
-										<li><code>Annotation.AnnotationTypeId</code>: <code>Header</code></li>
-									</ul>
-								</td>
-								<td>Expose <p><code>ROLE_HEADER</code> and object attribute
-											<code>xml-roles:doc-pageheader</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>&lt;nil&gt;</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "header" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-pagelist">
-								<th><a class="dpub-role-reference" href="#doc-pagelist"
-									><code>doc-pagelist</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-pagelist</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>pagelist</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>pagelist</code>'</li>
-									</ul>
-								</td>
-								<td>Expose <p><code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-pagelist</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkNavigation</code></li>
-										<li>AXRoleDescription: <code>'navigation'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "page list" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-part">
-								<th><a class="dpub-role-reference" href="#doc-part"><code>doc-part</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-part</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>part</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>part</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-part</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "part" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-preface">
-								<th><a class="dpub-role-reference" href="#doc-preface"><code>doc-preface</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARKi</code></li>
-										<li>Object attribute <code>xml-roles:doc-preface</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>preface</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>preface</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-preface</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "preface" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-prologue">
-								<th><a class="dpub-role-reference" href="#doc-prologue"
-									><code>doc-prologue</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-prologue</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>prologue</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>prologue</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-prologue</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkRegion</code></li>
-										<li>AXRoleDescription: <code>'region'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "prolog" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-pullquote">
-								<th><a class="dpub-role-reference" href="#doc-pullquote"
-									><code>doc-pullquote</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_SECTION</code></li>
-										<li>Object attribute <code>xml-roles:doc-pullquote</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>pullquote</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_SECTION</code> and object attribute
-											<code>xml-roles:doc-pullquote</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXApplicationGroup</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "pull quote" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-qna">
-								<th><a class="dpub-role-reference" href="#doc-preface"><code>doc-qna</code></a></th>
-								<td>Expose<p><code>IA2_ROLE_SECTION</code></p><p>IAccessible2:</p> Object attribute
-										<code>xml-roles:doc-qna</code></td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>qna</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_SECTION</code> and object attribute
-											<code>xml-roles:doc-qna</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXApplicationGroup</code></li>
-										<li>AXRoleDescription: <code>'group'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "Q&amp;A" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-subtitle">
-								<th><a class="dpub-role-reference" href="#doc-preface"
-									><code>doc-subtitle</code></a></th>
-								<td>Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_HEADING</code></li>
-										<li>Object attribute <code>xml-roles:doc-subtitle</code></li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>subtitle</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_HEADING</code> and object attribute
-											<code>xml-roles:doc-subtitle</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXHeading</code></li>
-										<li>AXSubrole: <code>AXSubtitle</code></li>
-										<li>AXRoleDescription: <code>'subtitle'</code></li>
-										<li>AXCustomContent: <code>{}</code></li>
-										<!-- intentionally blank -->
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-tip">
-								<th><a class="dpub-role-reference" href="#doc-tip"><code>doc-tip</code></a></th>
-								<td> Expose <p><code>IA2_ROLE_NOTE</code></p>
-									<p>IAccessible2:</p> Object attribute <code>xml-roles:doc-tip</code>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>tip</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_COMMENT</code> and object attribute
-											<code>xml-roles:doc-tip</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXDocumentNote</code></li>
-										<li>AXRoleDescription: <code>'note'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "tip" }</code></li>
-									</ul>
-								</td>
-							</tr>
-							<tr id="role-map-toc">
-								<th><a class="dpub-role-reference" href="#doc-toc"><code>doc-toc</code></a></th>
-								<td> Expose IAccessible2: <ul>
-										<li><code>IA2_ROLE_LANDMARK</code></li>
-										<li>Object attribute <code>xml-roles:doc-toc</code>
-										</li>
-									</ul>
-								</td>
-								<td>
-									<ul>
-										<li>Control Type is <code>Text</code></li>
-										<li>Localized Control Type is '<code>toc</code>'</li>
-										<li>Landmark Type is <code>Custom</code></li>
-										<li>Localized Landmark Type is '<code>toc</code>'</li>
-									</ul>
-								</td>
-								<td><p>Expose <code>ROLE_LANDMARK</code> and object attribute
-											<code>xml-roles:doc-toc</code>.</p></td>
-								<td>
-									<ul>
-										<li>AXRole: <code>AXGroup</code></li>
-										<li>AXSubrole: <code>AXLandmarkNavigation</code></li>
-										<li>AXRoleDescription: <code>'navigation'</code></li>
-										<li>AXCustomContent: <code>{ label: "type", value: "table of contents"
-											}</code></li>
-									</ul>
-								</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
+<h4 id=role-map-abstract><code>doc-abstract</code></h4>
+<table aria-labelledby=role-map-abstract>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-abstract"><code>doc-abstract</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_SECTION</code></li>
+          <li>Object attribute <code>xml-roles:doc-abstract</code>. </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>abstract</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_SECTION</code> and object attribute
+          <code>xml-roles:doc-abstract</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXApplicationGroup</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "abstract" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-acknowledgments><code>doc-acknowledgments</code></h4>
+<table aria-labelledby=role-map-acknowledgments>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-acknowledgments"><code>doc-acknowledgments</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-acknowledgments</code>. </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>acknowledgements</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>acknowledgements</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code><code>ROLE_LANDMARK</code></code> and object attribute
+          <code>xml-roles:doc-acknowledgments</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "acknowledgements"
+				}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-afterword><code>doc-afterword</code></h4>
+<table aria-labelledby=role-map-afterword>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-afterword"><code>doc-afterword</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-afterword</code>. </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>afterword</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>afterword</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-afterword</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "afterword" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-appendix><code>doc-appendix</code></h4>
+<table aria-labelledby=role-map-appendix>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-appendix"><code>doc-appendix</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-appendix</code>. </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>appendix</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>appendix</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-appendix</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "appendix" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-backlink><code>doc-backlink</code></h4>
+<table aria-labelledby=role-map-backlink>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-backlink"><code>doc-backlink</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <ul>
+          <li><code>ROLE_SYSTEM_LINK</code> + <code>STATE_LINKED</code></li>
+          <li><code>STATE_LINKED</code> on all descendants</li>
+        </ul>
+        <p>IAccessible2:</p>
+        <ul>
+          <li>Object attribute <code>xml-roles:doc-backlink</code>.</li>
+          <li><code>AccessibleHypertext</code> interface</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>backlink</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LINK</code> and object attribute
+          <code>xml-roles:doc-backlink</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXLink</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'link'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "back" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-biblioentry><code>doc-biblioentry</code></h4>
+<table aria-labelledby=role-map-biblioentry>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-biblioentry"><code>doc-biblioentry</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <p><code>ROLE_SYSTEM_LISTITEM</code> +
+          <code>STATE_SYSTEM_READONLY</code>
+        </p>
+        <p>IAccessible2:</p>
+        <p>Object attribute
+          <code>xml-roles:doc-biblioentry</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>biblioentry</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LIST_ITEM</code> and object attribute
+          <code>xml-roles:doc-bilioentry</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-bibliography><code>doc-bibliography</code></h4>
+<table aria-labelledby=role-map-bibliography>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-biblioentry"><code>doc-bibliography</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-bibliography</code>. </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>bibliography</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>biblography</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-bibliography</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "bibliography" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-biblioentry-implied><code>listitem</code> descendants of <code>doc-bibliography</code> (not descendant ofanother <code>listitem</code>)</h4>
+<table aria-labelledby=role-map-biblioentry-implied>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <code>listitem</code> descendants of <a class="dpub-role-reference" href="#doc-bibliography"><code>doc-bibliography</code></a> (not descendant ofanother <code>listitem</code>)
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <p><code>ROLE_SYSTEM_LISTITEM</code> +
+          <code>STATE_SYSTEM_READONLY</code>
+        </p>
+        <p>IAccessible2:</p>
+        <p>Object attribute
+          <code>xml-roles:doc-biblioentry</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>biblioentry</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LIST_ITEM</code> and object attribute
+          <code>xml-roles:doc-bilioentry</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-biblioref><code>doc-biblioref</code></h4>
+<table aria-labelledby=role-map-biblioref>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-biblioref"><code>doc-biblioref</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <ul>
+          <li><code>ROLE_SYSTEM_LINK</code> + <code>STATE_LINKED</code></li>
+          <li><code>STATE_LINKED</code> on all descendants</li>
+        </ul>
+        <p>IAccessible2:</p>
+        <ul>
+          <li>Object attribute <code>xml-roles:doc-biblioref</code>.</li>
+          <li><code>AccessibleHypertext</code> interface</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>biblioref</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LINK</code> and object attribute
+          <code>xml-roles:doc-biblioref</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXLink</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'link'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "bibliography" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-chapter><code>doc-chapter</code></h4>
+<table aria-labelledby=role-map-chapter>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-chapter"><code>doc-chapter</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-chapter</code>. </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>chapter</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>chapter</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:chapter</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkChapter</code></li>
+          <li>AXRoleDescription: <code>'chapter'</code></li>
+          <li>AXCustomContent: <code>{}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-colophon><code>doc-colophon</code></h4>
+<table aria-labelledby=role-map-colophon>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-colophon"><code>doc-colophon</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose<p><code>IA2_ROLE_SECTION</code></p>
+        <p>IAccessible2: Object attribute
+          <code>xml-roles:doc-colophon</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>colophon</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_SECTION</code> and object attribute
+          <code>xml-roles:doc-colophon</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXApplicationGroup</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "colophon" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-conclusion><code>doc-conclusion</code></h4>
+<table aria-labelledby=role-map-conclusion>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-conclusion"><code>doc-conclusion</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-conclusion</code>. </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>conclusion</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>conclusion</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-conclusion</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "conclusion" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-cover><code>doc-cover</code></h4>
+<table aria-labelledby=role-map-cover>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-cover"><code>doc-cover</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <p><code>ROLE_SYSTEM_GRAPHIC</code></p>
+        <p>IAccessible2: Object attribute <code>xml-roles:doc-cover</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        Control Type is <code>Image</code>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>expose <code>ROLE_IMAGE</code> and object attribute
+          <code>xml-roles:doc-cover</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXImage</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'cover image'</code></li>
+          <li>AXCustomContent: <code>{}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-credit><code>doc-credit</code></h4>
+<table aria-labelledby=role-map-credit>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-cover"><code>doc-credit</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose<p><code>IA2_ROLE_SECTION</code></p>
+        <p>IAccessible2:</p> Object attribute
+        <code>xml-roles:doc-credit</code>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>credit</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_SECTION</code> and object attribute
+          <code>xml-roles:doc-credit</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXApplicationGroup</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-credits><code>doc-credits</code></h4>
+<table aria-labelledby=role-map-credits>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-credits"><code>doc-credits</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-credits</code>. </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>credits</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>credits</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-credits</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "credits" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-dedication><code>doc-dedication</code></h4>
+<table aria-labelledby=role-map-dedication>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-dedication"><code>doc-dedication</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose<p><code>IA2_ROLE_SECTION</code></p>
+        <p>IAccessible2:</p> Object attribute
+        <code>xml-roles:doc-dedication</code>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>dedication</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_SECTION</code> and object attribute
+          <code>xml-roles:doc-dedication</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXApplicationGroup</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "dedication" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-endnote><code>doc-endnote</code></h4>
+<table aria-labelledby=role-map-endnote>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-endnote"><code>doc-endnote</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <p><code>ROLE_SYSTEM_LISTITEM</code> +
+          <code>STATE_SYSTEM_READONLY</code>
+        </p>
+        <p>IAccessible2:</p>
+        <p>Object attribute <code>xml-roles:doc-endnote</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>endnote</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LIST_ITEM</code> and object attribute
+          <code>xml-roles:doc-endnote</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-endnotes><code>doc-endnotes</code></h4>
+<table aria-labelledby=role-map-endnotes>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-endnote"><code>doc-endnotes</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-endnotes</code>. </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>endnotes</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>endnotes</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-endnotes</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "end notes" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-endnote-implied><code>listitem</code> descendants of <code>doc-endnotes</code> (not descendant of another<code>listitem</code>)</h4>
+<table aria-labelledby=role-map-endnote-implied>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <code>listitem</code> descendants of <a class="dpub-role-reference" href="#doc-endnotes"><code>doc-endnotes</code></a> (not descendant of another<code>listitem</code>)
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <p><code>ROLE_SYSTEM_LISTITEM</code> +
+          <code>STATE_SYSTEM_READONLY</code>
+        </p>
+        <p>IAccessible2:</p>
+        <p>Object attribute <code>xml-roles:doc-endnote</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>endnote</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LIST_ITEM</code> and object attribute
+          <code>xml-roles:doc-endnote</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-epigraph><code>doc-epigraph</code></h4>
+<table aria-labelledby=role-map-epigraph>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-epigraph"><code>doc-epigraph</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose<p><code>IA2_ROLE_SECTION</code></p>
+        <p>IAccessible2:</p> Object attribute
+        <code>xml-roles:doc-epigraph</code>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>epigraph</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_SECTION</code> and object attribute
+          <code>xml-roles:doc-epigraph</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXApplicationGroup</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "epigraph" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-epilogue><code>doc-epilogue</code></h4>
+<table aria-labelledby=role-map-epilogue>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-epilogue"><code>doc-epilogue</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-epilogue</code>. </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>epilogue</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>epilogue</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-epilogue</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "epilog" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-errata><code>doc-errata</code></h4>
+<table aria-labelledby=role-map-errata>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-cover"><code>doc-errata</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-errata</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>errata</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>errata</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-errata</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "errata" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-example><code>doc-example</code></h4>
+<table aria-labelledby=role-map-example>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-cover"><code>doc-example</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose<p><code>IA2_ROLE_SECTION</code></p>
+        <p>IAccessible2:</p> Object attribute
+        <code>xml-roles:doc-example</code>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>example</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_SECTION</code> and object attribute
+          <code>xml-roles:doc-example</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXApplicationGroup</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "example" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-footnote><code>doc-footnote</code></h4>
+<table aria-labelledby=role-map-footnote>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-footnote"><code>doc-footnote</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        <p>Expose IAccessible2:</p>
+        <ul>
+          <li><code>IA2_ROLE_FOOTNOTE</code></li>
+          <li>Object attribute: <code>xml-roles:doc-footnote</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>footnote</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_FOOTNOTE</code> and object attribute
+          <code>xml-roles:doc-footnote</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXApplicationGroup</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "footnote" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-foreword><code>doc-foreword</code></h4>
+<table aria-labelledby=role-map-foreword>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-foreword"><code>doc-foreword</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-foreword</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>foreword</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>foreword</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-foreword</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "foreword" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-glossary><code>doc-glossary</code></h4>
+<table aria-labelledby=role-map-glossary>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-glossary"><code>doc-glossary</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-glossary</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>glossary</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>glossary</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-glossary</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "glossary" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-glossref><code>doc-glossref</code></h4>
+<table aria-labelledby=role-map-glossref>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-glossref"><code>doc-glossref</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <ul>
+          <li><code>ROLE_SYSTEM_LINK</code> + <code>STATE_LINKED</code></li>
+          <li><code>STATE_LINKED</code> on all descendants</li>
+        </ul>
+        <p>IAccessible2:</p>
+        <ul>
+          <li>Object attribute <code>xml-roles:doc-glossref</code>.</li>
+          <li><code>AccessibleHypertext</code> interface</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>glossref</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LINK</code> and object attribute
+          <code>xml-roles:doc-glossref</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXLink</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'link'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "glossary" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-index><code>doc-index</code></h4>
+<table aria-labelledby=role-map-index>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-index"><code>doc-index</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-index</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>index</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>index</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-index</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkNavigation</code></li>
+          <li>AXRoleDescription: <code>'navigation'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "index" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-introduction><code>doc-introduction</code></h4>
+<table aria-labelledby=role-map-introduction>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-introduction"><code>doc-introduction</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-introduction</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>introduction</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>introduction</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-introduction</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "introduction" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-noteref><code>doc-noteref</code></h4>
+<table aria-labelledby=role-map-noteref>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-noteref"><code>doc-noteref</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <ul>
+          <li><code>ROLE_SYSTEM_LINK</code> + <code>STATE_LINKED</code></li>
+          <li><code>STATE_LINKED</code> on all descendants</li>
+        </ul>
+        <p>IAccessible2:</p>
+        <ul>
+          <li>Object attribute <code>xml-roles:doc-noteref</code>.</li>
+          <li><code>AccessibleHypertext</code> interface</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>noteref</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LINK</code> and object attribute
+          <code>xml-roles:doc-noteref</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXLink</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'link'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "note" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-notice><code>doc-notice</code></h4>
+<table aria-labelledby=role-map-notice>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-notice"><code>doc-notice</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <p><code>IA2_ROLE_NOTE</code></p>
+        <p>IAccessible2:</p> Object attribute <code>xml-roles:doc-notice</code>.
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>notice</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_COMMENT</code> and object attribute
+          <code>xml-roles:doc-notice</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXDocumentNote</code></li>
+          <li>AXRoleDescription: <code>'note'</code></li>
+          <li>AXCustomContent: <code>{}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-pagebreak><code>doc-pagebreak</code></h4>
+<table aria-labelledby=role-map-pagebreak>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-pagebreak"><code>doc-pagebreak</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <p><code>ROLE_SYSTEM_SEPARATOR</code></p>
+        <p>IAccessible2:</p> Object attribute <code>xml-roles:doc-pagebreak</code>.
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>pagebreak</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_SEPARATOR</code> and object attribute
+          <code>xml-roles:doc-pagebreak</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXSplitter</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'splitter'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "page break" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-pagefooter><code>doc-pagefooter</code></h4>
+<table aria-labelledby=role-map-pagefooter>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-pagefooter"><code>doc-pagefooter</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_FOOTER</code></li>
+          <li>Object attribute <code>xml-roles:doc-pagefooter</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Control Pattern: <code>Annotation</code></li>
+          <li><code>Annotation.AnnotationTypeId</code>: <code>Footer</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        Expose <p><code>ROLE_FOOTER</code> and object attribute
+          <code>xml-roles:doc-pagefooter</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "footer" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-pageheader><code>doc-pageheader</code></h4>
+<table aria-labelledby=role-map-pageheader>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-pageheader"><code>doc-pageheader</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_HEADER</code></li>
+          <li>Object attribute <code>xml-roles:doc-pageheader</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Control Pattern: <code>Annotation</code></li>
+          <li><code>Annotation.AnnotationTypeId</code>: <code>Header</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        Expose <p><code>ROLE_HEADER</code> and object attribute
+          <code>xml-roles:doc-pageheader</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "header" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-pagelist><code>doc-pagelist</code></h4>
+<table aria-labelledby=role-map-pagelist>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-pagelist"><code>doc-pagelist</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-pagelist</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>pagelist</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>pagelist</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        Expose <p><code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-pagelist</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkNavigation</code></li>
+          <li>AXRoleDescription: <code>'navigation'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "page list" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-part><code>doc-part</code></h4>
+<table aria-labelledby=role-map-part>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-part"><code>doc-part</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-part</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>part</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>part</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-part</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "part" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-preface><code>doc-preface</code></h4>
+<table aria-labelledby=role-map-preface>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-preface"><code>doc-preface</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARKi</code></li>
+          <li>Object attribute <code>xml-roles:doc-preface</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>preface</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>preface</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-preface</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "preface" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-prologue><code>doc-prologue</code></h4>
+<table aria-labelledby=role-map-prologue>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-prologue"><code>doc-prologue</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-prologue</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>prologue</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>prologue</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-prologue</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkRegion</code></li>
+          <li>AXRoleDescription: <code>'region'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "prolog" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-pullquote><code>doc-pullquote</code></h4>
+<table aria-labelledby=role-map-pullquote>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-pullquote"><code>doc-pullquote</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_SECTION</code></li>
+          <li>Object attribute <code>xml-roles:doc-pullquote</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>pullquote</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_SECTION</code> and object attribute
+          <code>xml-roles:doc-pullquote</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXApplicationGroup</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "pull quote" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-qna><code>doc-qna</code></h4>
+<table aria-labelledby=role-map-qna>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-preface"><code>doc-qna</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose<p><code>IA2_ROLE_SECTION</code></p>
+        <p>IAccessible2:</p> Object attribute
+        <code>xml-roles:doc-qna</code>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>qna</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_SECTION</code> and object attribute
+          <code>xml-roles:doc-qna</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXApplicationGroup</code></li>
+          <li>AXRoleDescription: <code>'group'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "Q&amp;A" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-subtitle><code>doc-subtitle</code></h4>
+<table aria-labelledby=role-map-subtitle>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-preface"><code>doc-subtitle</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_HEADING</code></li>
+          <li>Object attribute <code>xml-roles:doc-subtitle</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>subtitle</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_HEADING</code> and object attribute
+          <code>xml-roles:doc-subtitle</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXHeading</code></li>
+          <li>AXSubrole: <code>AXSubtitle</code></li>
+          <li>AXRoleDescription: <code>'subtitle'</code></li>
+          <li>AXCustomContent: <code>{}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-tip><code>doc-tip</code></h4>
+<table aria-labelledby=role-map-tip>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-tip"><code>doc-tip</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose <p><code>IA2_ROLE_NOTE</code></p>
+        <p>IAccessible2:</p> Object attribute <code>xml-roles:doc-tip</code>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>tip</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_COMMENT</code> and object attribute
+          <code>xml-roles:doc-tip</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXDocumentNote</code></li>
+          <li>AXRoleDescription: <code>'note'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "tip" }</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id=role-map-toc><code>doc-toc</code></h4>
+<table aria-labelledby=role-map-toc>
+  <tbody>
+    <tr>
+      <th>DPUB-ARIA Specification</th>
+      <td>
+        <a class="dpub-role-reference" href="#doc-toc"><code>doc-toc</code></a>
+      </td>
+    </tr>
+    <tr>
+      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
+      <td>
+        Expose IAccessible2: <ul>
+          <li><code>IA2_ROLE_LANDMARK</code></li>
+          <li>Object attribute <code>xml-roles:doc-toc</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
+        Features</th>
+      <td>
+        <ul>
+          <li>Control Type is <code>Text</code></li>
+          <li>Localized Control Type is '<code>toc</code>'</li>
+          <li>Landmark Type is <code>Custom</code></li>
+          <li>Localized Landmark Type is '<code>toc</code>'</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
+        Role</th>
+      <td>
+        <p>Expose <code>ROLE_LANDMARK</code> and object attribute
+          <code>xml-roles:doc-toc</code>.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
+      <td>
+        <ul>
+          <li>AXRole: <code>AXGroup</code></li>
+          <li>AXSubrole: <code>AXLandmarkNavigation</code></li>
+          <li>AXRoleDescription: <code>'navigation'</code></li>
+          <li>AXCustomContent: <code>{ label: "type", value: "table of contents"
+				}</code></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
 			</section>
 		</section>
 		<section id="translatable-values">


### PR DESCRIPTION
Githack link, as PR Preview doesn't include styles: https://raw.githack.com/w3c/dpub-aam/remove-table/index.html


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/pull/31.html" title="Last updated on Aug 22, 2023, 2:46 PM UTC (a3427ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/31/2b231ed...a3427ae.html" title="Last updated on Aug 22, 2023, 2:46 PM UTC (a3427ae)">Diff</a>