### PR TITLE
editorial: github contributors section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2804,7 +2804,9 @@
 				<h3>Acknowledgments</h3>
 
 				<p>The following people contributed to the development of this document.</p>
-
+				<ul id="gh-contributors">
+					<!-- list of contributors will appear here, along with link to their GitHub profiles -->
+				</ul>
 				<section class="section" id="ack_dpub">
 					<h4>Participants active in the DPUB-ARIA task force at the time of publication</h4>
 


### PR DESCRIPTION
Adds a new GH contributors section, matching other ARIA specs.

See w3c/aria-common#103 for more background.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/pull/37.html" title="Last updated on Nov 10, 2023, 1:15 PM UTC (3ed929b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/37/dcbadd2...3ed929b.html" title="Last updated on Nov 10, 2023, 1:15 PM UTC (3ed929b)">Diff</a>