### PR TITLE
Removed mappings that imply deprecated roles on list items

### DIFF
--- a/index.html
+++ b/index.html
@@ -2672,6 +2672,8 @@
 							>First Public Working Draft</a></h3>
 
 					<ul>
+						<li>01-Dec-2023: Removed the mappings that implied doc-biblioentry and doc-endnote on listitem
+							descendants doc-bibliograph and doc-endnotes, respectively.</li>
 						<li>10-Jan-2023: Added section on translatable values.</li>
 						<li>04-Jan-2023: Fixed incorrect doc-pagebreak role mentioned in ATK/AT-SPI mapping for
 							doc-preface.</li>

--- a/index.html
+++ b/index.html
@@ -691,63 +691,6 @@
     </tr>
   </tbody>
 </table>
-<h4 id=role-map-biblioentry-implied><code>listitem</code> descendants of <code>doc-bibliography</code> (not descendant ofanother <code>listitem</code>)</h4>
-<table aria-labelledby=role-map-biblioentry-implied>
-  <tbody>
-    <tr>
-      <th>DPUB-ARIA Specification</th>
-      <td>
-        <code>listitem</code> descendants of <a class="dpub-role-reference" href="#doc-bibliography"><code>doc-bibliography</code></a> (not descendant ofanother <code>listitem</code>)
-      </td>
-    </tr>
-    <tr>
-      <th><a class="core-mapping" data-cite="core-aam-1.2#roleMappingComputedRole">Computed Role</a></th>
-      <td><code>doc-biblioentry</code></td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
-      <td>
-        Expose <p><code>ROLE_SYSTEM_LISTITEM</code> +
-          <code>STATE_SYSTEM_READONLY</code>
-        </p>
-        <p>IAccessible2:</p>
-        <p>Object attribute
-          <code>xml-roles:doc-biblioentry</code>.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
-        Features</th>
-      <td>
-        <ul>
-          <li>Control Type is <code>Text</code></li>
-          <li>Localized Control Type is '<code>biblioentry</code>'</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
-        Role</th>
-      <td>
-        <p>Expose <code>ROLE_LIST_ITEM</code> and object attribute
-          <code>xml-roles:doc-bilioentry</code>.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
-      <td>
-        <ul>
-          <li>AXRole: <code>AXGroup</code></li>
-          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
-          <li>AXRoleDescription: <code>'group'</code></li>
-          <li>AXCustomContent: <code>{}</code></li>
-        </ul>
-      </td>
-    </tr>
-  </tbody>
-</table>
 <h4 id=role-map-biblioref><code>doc-biblioref</code></h4>
 <table aria-labelledby=role-map-biblioref>
   <tbody>
@@ -1290,61 +1233,6 @@
           <li>AXSubrole: <code>AXLandmarkRegion</code></li>
           <li>AXRoleDescription: <code>'region'</code></li>
           <li>AXCustomContent: <code>{ label: "type", value: "end notes" }</code></li>
-        </ul>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h4 id=role-map-endnote-implied><code>listitem</code> descendants of <code>doc-endnotes</code> (not descendant of another<code>listitem</code>)</h4>
-<table aria-labelledby=role-map-endnote-implied>
-  <tbody>
-    <tr>
-      <th>DPUB-ARIA Specification</th>
-      <td>
-        <code>listitem</code> descendants of <a class="dpub-role-reference" href="#doc-endnotes"><code>doc-endnotes</code></a> (not descendant of another<code>listitem</code>)
-      </td>
-    </tr>
-    <tr>
-      <th><a class="core-mapping" data-cite="core-aam-1.2#roleMappingComputedRole">Computed Role</a></th>
-      <td><code>doc-endnote</code></td>
-    </tr>
-    <tr>
-      <th>MSAA + IAccessible2 Role + Other IAccessible2 Features</th>
-      <td>
-        Expose <p><code>ROLE_SYSTEM_LISTITEM</code> +
-          <code>STATE_SYSTEM_READONLY</code>
-        </p>
-        <p>IAccessible2:</p>
-        <p>Object attribute <code>xml-roles:doc-endnote</code>.</p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="User Interface Automation">UIA</abbr> Control Type + Other
-        Features</th>
-      <td>
-        <ul>
-          <li>Control Type is <code>Text</code></li>
-          <li>Localized Control Type is '<code>endnote</code>'</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Accessibility Toolkit">ATK</abbr>/<abbr title="Assistive Technology - Service Provider Interface">AT-SPI</abbr>
-        Role</th>
-      <td>
-        <p>Expose <code>ROLE_LIST_ITEM</code> and object attribute
-          <code>xml-roles:doc-endnote</code>.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <th><abbr title="Mac OS X Accessibility Protocol">Mac AX API</abbr></th>
-      <td>
-        <ul>
-          <li>AXRole: <code>AXGroup</code></li>
-          <li>AXSubrole: <code>&lt;nil&gt;</code></li>
-          <li>AXRoleDescription: <code>'group'</code></li>
-          <li>AXCustomContent: <code>{}</code></li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
As discovered in #34, the two mappings removed in this pull request added the doc-biblioentry and doc-endnote roles to list items within their respective parent roles even though the roles themselves are deprecated and not expected to be used.

The mappings appear to come from the statements like this in DPUB-ARIA:

> User Agents MUST expose the list items in these lists using the platform accessibility API mappings for an individual endnote.
> 
> Lists nested within an endnote have no special significance. User Agents MUST NOT expose these list items using the platform accessibility API mappings for an individual endnote.

If we're deprecating the roles, then these statements also need to be removed, else it begs the question why are we deprecating the roles at the same time as we're requiring them to be implied? We can't remove the required child roles and then require a structure to imply them onto. But I'll open another pull request on that specification to remove the statements next.

Fixes #34


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/pull/38.html" title="Last updated on Dec 1, 2023, 6:55 PM UTC (9ed607e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aam/38/dcbadd2...9ed607e.html" title="Last updated on Dec 1, 2023, 6:55 PM UTC (9ed607e)">Diff</a>